### PR TITLE
HTML Apostrophe

### DIFF
--- a/503.php
+++ b/503.php
@@ -1,4 +1,3 @@
-
 <?php get_header(); ?>
 
 	<div class="container content">
@@ -7,9 +6,9 @@
 
 			<div class="col-md-12">
 
-				<h1><?php _e( 'We\'ll be back!', 'govfreshwp' ); ?></h1>
+				<h1><?php _e( 'We&rsquo;ll be back!', 'govfreshwp' ); ?></h1>
 
-				<p><?php _e( 'We\'re updating the site. We\'ll be back shortly.', 'govfreshwp' ); ?></p>
+				<p><?php _e( 'We&rsquo;re updating the site. We&rsquo;ll be back shortly.', 'govfreshwp' ); ?></p>
 
 			</div>
 


### PR DESCRIPTION
Proposing to use `&rsquo;` -vs  `\`  `&rsquo;` will always return proper apostrophe.
