### PR TITLE
Apostrophe for translation string

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -1,4 +1,3 @@
-
 <?php get_header(); ?>
 
 	<div class="container content">
@@ -67,12 +66,12 @@
 				<?php
 
 				if ( is_category() ) { // If this is a category archive
-				printf("<h2>Sorry, but there aren't any posts in the %s category yet.</h2>", single_cat_title('',false));
+				printf("<h2>Sorry, but there aren&rsquo;t any posts in the %s category yet.</h2>", single_cat_title('',false));
 				} else if ( is_date() ) { // If this is a date archive
-				echo("<h2>Sorry, but there aren't any posts with this date.</h2>");
+				echo("<h2>Sorry, but there aren&rsquo;t any posts with this date.</h2>");
 				} else if ( is_author() ) { // If this is a category archive
 				$userdata = get_userdatabylogin(get_query_var('author_name'));
-				printf("<h2>Sorry, but there aren't any posts by %s yet.</h2>", $userdata->display_name);
+				printf("<h2>Sorry, but there aren&rsquo;t any posts by %s yet.</h2>", $userdata->display_name);
 				} else {
 				echo("<h2>No posts found.</h2>");
 				}


### PR DESCRIPTION
Using `&rsquo;` instead of `'` is slightly better for translations.
